### PR TITLE
waypoints must include accuracy by specification

### DIFF
--- a/geomock.coffee
+++ b/geomock.coffee
@@ -48,14 +48,14 @@ do ->
       clearInterval id
     
     waypoints : [
-      {coords : {latitude : 52.5168, longitude : 13.3889 }},
-      {coords : {latitude : 52.5162, longitude : 13.3890 }},
-      {coords : {latitude : 52.5154, longitude : 13.3890 }},
-      {coords : {latitude : 52.5150, longitude : 13.3890 }}, 
-      {coords : {latitude : 52.5144, longitude : 13.3890 }}, 
-      {coords : {latitude : 52.5138, longitude : 13.3890 }}, 
-      {coords : {latitude : 52.5138, longitude : 13.3895 }}, 
-      {coords : {latitude : 52.5139, longitude : 13.3899 }}, 
-      {coords : {latitude : 52.5140, longitude : 13.3906 }}, 
-      {coords : {latitude : 52.5140, longitude : 13.3910 }}
+      {coords : {latitude : 52.5168, longitude : 13.3889, accuracy: 1500 }},
+      {coords : {latitude : 52.5162, longitude : 13.3890, accuracy: 1334 }},
+      {coords : {latitude : 52.5154, longitude : 13.3890, accuracy: 631  }},
+      {coords : {latitude : 52.5150, longitude : 13.3890, accuracy: 361  }},
+      {coords : {latitude : 52.5144, longitude : 13.3890, accuracy: 150  }},
+      {coords : {latitude : 52.5138, longitude : 13.3890, accuracy: 65   }},
+      {coords : {latitude : 52.5138, longitude : 13.3895, accuracy: 65   }},
+      {coords : {latitude : 52.5139, longitude : 13.3899, accuracy: 65   }},
+      {coords : {latitude : 52.5140, longitude : 13.3906, accuracy: 65   }},
+      {coords : {latitude : 52.5140, longitude : 13.3910, accuracy: 65   }}
     ]

--- a/geomock.js
+++ b/geomock.js
@@ -49,52 +49,62 @@
         {
           coords: {
             latitude: 52.5168,
-            longitude: 13.3889
+            longitude: 13.3889,
+            accuracy: 1500
           }
         }, {
           coords: {
             latitude: 52.5162,
-            longitude: 13.3890
+            longitude: 13.3890,
+            accuracy: 1334
           }
         }, {
           coords: {
             latitude: 52.5154,
-            longitude: 13.3890
+            longitude: 13.3890,
+            accuracy: 631
           }
         }, {
           coords: {
             latitude: 52.5150,
-            longitude: 13.3890
+            longitude: 13.3890,
+            accuracy: 361
           }
         }, {
           coords: {
             latitude: 52.5144,
-            longitude: 13.3890
+            longitude: 13.3890,
+            accuracy: 150
           }
         }, {
           coords: {
             latitude: 52.5138,
-            longitude: 13.3890
+            longitude: 13.3890,
+            accuracy: 65
           }
         }, {
           coords: {
             latitude: 52.5138,
-            longitude: 13.3895
+            longitude: 13.3895,
+            accuracy: 65
           }
         }, {
           coords: {
             latitude: 52.5139,
-            longitude: 13.3899
+            longitude: 13.3899,
+            accuracy: 65
           }
         }, {
           coords: {
             latitude: 52.5140,
-            longitude: 13.3906
+            longitude: 13.3906,
+            accuracy: 65
           }
         }, {
           coords: {
             latitude: 52.5140,
-            longitude: 13.3910
+            longitude: 13.3910,
+            accuracy: 65
           }
         }
       ]

--- a/geomock.js
+++ b/geomock.js
@@ -5,7 +5,7 @@
   GeoMock is licensed under the MIT license.
   */  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
   (function() {
-    if (typeof navigator == "undefined" || navigator === null) {
+    if (typeof navigator === "undefined" || navigator === null) {
       window.navigator = {};
     }
     delete navigator.geolocation;


### PR DESCRIPTION
Refs - #2

I took seed data for accuracy fields from real production database - https://gist.github.com/1900399

It usually starts with less precise values and getting better and better as you continue to `watchPosition`.
